### PR TITLE
Change packaging to bundle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
 	<version>0.2.1-SNAPSHOT</version>
 	<name>TrieMap</name>
 	<description>Java implementation of a concurrent trie hash map from Scala collections library</description>
+	<packaging>bundle</packaging>
 	<url>https://github.com/romix/java-concurrent-hash-trie-map</url>
 	<licenses>
 		<license>
@@ -22,8 +23,8 @@
 		<url>https://github.com/romix/java-concurrent-hash-trie-map</url>
 		<connection>scm:git:https://github.com/romix/java-concurrent-hash-trie-map.git</connection>
 		<developerConnection>scm:git:https://github.com/romix/java-concurrent-hash-trie-map.git</developerConnection>
-	  <tag>HEAD</tag>
-  </scm>
+		<tag>HEAD</tag>
+	</scm>
 	<developers>
 		<developer>
 			<id>romix</id>
@@ -51,6 +52,17 @@
 					<checkModificationExcludes>
 						<checkModificationExclude>pom.xml</checkModificationExclude>
 					</checkModificationExcludes>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<version>2.4.0</version>
+				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Bundle-Name>${project.groupId}.${project.artifactId}</Bundle-Name>
+					</instructions>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
This emits proper OSGi manifest, so the resulting jar can be used as a
bundle.

Signed-off-by: Robert Varga robert.varga@pantheon.sk
