### PR TITLE
Rework read-only tracking

### DIFF
--- a/src/test/java/com/romix/scala/collection/concurrent/TestSerialization.java
+++ b/src/test/java/com/romix/scala/collection/concurrent/TestSerialization.java
@@ -13,12 +13,14 @@ import org.junit.Test;
 public class TestSerialization {
     @Test
     public void testSerialization() throws IOException, ClassNotFoundException {
-        TrieMap<String, String> expected = new TrieMap<String, String>();
+        TrieMap<String, String> map = new TrieMap<String, String>();
 
-        expected.put("dude-0", "tom");
-        expected.put("dude-1", "john");
-        expected.put("dude-3", "ravi");
-        expected.put("dude-4", "alex");
+        map.put("dude-0", "tom");
+        map.put("dude-1", "john");
+        map.put("dude-3", "ravi");
+        map.put("dude-4", "alex");
+
+        TrieMap<String, String> expected = map.readOnlySnapshot();
 
         final ByteArrayOutputStream bos = new ByteArrayOutputStream();
         final ObjectOutputStream oos = new ObjectOutputStream(bos);


### PR DESCRIPTION
This builds on top of pull request #14, and changes how read-only is tracked. Instead of tracking a reference, there is final boolean field which is checked before the static updater is touched.

It should have the same (or slightly better) performance characteristics, that may or may not be true.
