### PR TITLE
Switch the test to make sure we are measuring the constructor

### DIFF
--- a/src/test/java/com/romix/scala/collection/concurrent/TestInstantiationSpeed.java
+++ b/src/test/java/com/romix/scala/collection/concurrent/TestInstantiationSpeed.java
@@ -12,7 +12,7 @@ public class TestInstantiationSpeed {
         final long start = System.nanoTime();
 
         for (int i = 0; i < COUNT; ++i) {
-            maps[i] = TrieMap.empty();
+            maps[i] = new TrieMap<Object, Object>();
         }
 
         final long stop = System.nanoTime();


### PR DESCRIPTION
Since TrieMap.empty() now returns a shared instance, we really want to
measure the constructor.

Signed-off-by: Robert Varga robert.varga@pantheon.sk
