### PR TITLE
Use equal() instead of identity in readonly TNode

### DIFF
--- a/src/main/java/com/romix/scala/collection/concurrent/TrieMap.java
+++ b/src/main/java/com/romix/scala/collection/concurrent/TrieMap.java
@@ -461,7 +461,7 @@ public class TrieMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
                 clean (parent, ct, lev - 5);
                 return RESTART; // used to be throw RestartException
             } else {
-                if (tn.hc == hc && tn.k == k)
+                if (tn.hc == hc && equal(tn.k, k, ct))
                     return tn.v;
                 else
                     return null;


### PR DESCRIPTION
Instead of requiring a match on identity, use equal()
to compare the stored and lookup keys. This fixes
https://bugs.opendaylight.org/show_bug.cgi?id=6577.

Signed-off-by: Robert Varga <nite@hq.sk>