### PR TITLE
Fix putIfAbsent / rec_insertif in case of an LNode and current node value is None (instead of null).

### DIFF
--- a/src/main/java/com/romix/scala/collection/concurrent/TrieMap.java
+++ b/src/main/java/com/romix/scala/collection/concurrent/TrieMap.java
@@ -359,7 +359,7 @@ public class TrieMap<K, V> extends AbstractMap<K, V> implements ConcurrentMap<K,
                             return null;
                     } else if (cond == INode.KEY_ABSENT) {
                         Option<V> t = ln.get (k);
-                        if (t == null) {
+                        if (t == null || t instanceof None) {
                             if (insertln (ln, k, v, ct))
                                 return Option.makeOption ();// None
                             else


### PR DESCRIPTION
This small code change fixes the handling of LNode "KEY_ABSENT" case when adding element to TrieMap. The problem is that getting current value from node (from it's internal ListMap) can never return null. It will return either Some or None. So the current check for null will not add element to node if that get will return None falsely assuming that element already exists.
In the scala source version there is also only pattern match for None and Some.